### PR TITLE
WK fixes

### DIFF
--- a/rswag-api/lib/rswag/api/middleware.rb
+++ b/rswag-api/lib/rswag/api/middleware.rb
@@ -19,7 +19,7 @@ module Rswag
           swagger = parse_file(filename)
           @config.swagger_filter.call(swagger, env) unless @config.swagger_filter.nil?
           mime = Rack::Mime.mime_type(::File.extname(path), 'text/plain')
-          headers = { 'Content-Type' => mime }.merge(@config.swagger_headers || {})
+          headers = { 'Content-Type' => "#{mime}; charset=UTF-8" }.merge(@config.swagger_headers || {})
           body = unload_swagger(filename, swagger)
 
           return [

--- a/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
+++ b/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
@@ -15,7 +15,7 @@ RSpec.configure do |config|
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.swagger_docs = {
-    'v1/swagger.yaml' => {
+    'v1/swagger.json' => {
       openapi: '3.0.1',
       info: {
         title: 'API V1',
@@ -39,5 +39,5 @@ RSpec.configure do |config|
   # The swagger_docs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
-  config.swagger_format = :yaml
+  config.swagger_format = :json
 end

--- a/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
+++ b/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
@@ -24,10 +24,10 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: 'https://{defaultHost}',
+          url: '{defaultHost}',
           variables: {
             defaultHost: {
-              default: 'www.example.com'
+              default: 'https://localhost:3000'
             }
           }
         }

--- a/rswag-specs/lib/rswag-specs.rb
+++ b/rswag-specs/lib/rswag-specs.rb
@@ -1,0 +1,1 @@
+require 'rswag/specs'

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -100,6 +100,13 @@ module Rswag
           end
         end
       end
+      
+      def save_example!
+        after do |example|
+          # TODO: Remove hardcoded application/json content-type. Receive it from actual response
+          example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
+        end
+      end
     end
   end
 end

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -136,8 +136,17 @@ module Rswag
         target_node.merge!(content: {})
 
         mime_list.each do |mime_type|
-          # TODO upgrade to have content-type specific schema
-          (target_node[:content][mime_type] ||= {}).merge!(schema: schema)
+          content_value = { schema: schema }
+
+          example = target_node.dig(:examples, mime_type)
+
+          if example.present?
+            # TODO: This solution can't let you add multiple examples. It should be more flexible
+            content_value.merge!(examples: { 'Example' => { 'value' => example } })
+          end
+
+          target_node[:content][mime_type] = content_value
+          target_node.delete(:examples)
         end
       end
 


### PR DESCRIPTION
- rswag-api: Add charset to content-type header
- rswag-specs: Make protocol variable for defaultHost
- rswag-specs: Add rswag-specs.rb file for bootsnap compatibility
- rswag-specs: Fix examples syntax to match open api v3 specifications
- rswag-specs: Add save_example! helper
- rswag-specs: Use json as default swagger format
